### PR TITLE
fix: update for Helm 3.7+ compatibility

### DIFF
--- a/helm/nyan/templates/ingress.yaml
+++ b/helm/nyan/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "nyan.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "nyan.fullname" . }}
@@ -20,9 +20,12 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}/?(.*)
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
   {{- end }}
 status:
   loadBalancer:


### PR DESCRIPTION
Update for recent versions, networking.k8s.io/v1beta1 being deprecated.
Successfully tested on local using Kind.